### PR TITLE
getDatasetSiteTemplate callback error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ function getDistFullPath(filename) {
 
 async function getDatasetSiteTemplate(singleFileMode) {
   // Get pre-rendered template from ./dist/
-  return await fs.readFile(getDistFullPath(getDatasetSiteTemplateFilename(singleFileMode)), { encoding:'utf8' });
+  return await fs.promises.readFile(getDistFullPath(getDatasetSiteTemplateFilename(singleFileMode)), { encoding:'utf8' });
 }
 
 function getDatasetSiteTemplateSync(singleFileMode) {


### PR DESCRIPTION
Fix for: [ERROR] TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received { encoding: 'utf8' }. Use fs.promises.readFile() which doesn't need a callback argument