### PR TITLE
fix: renderDatasetSite

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const Mustache = require('mustache');
-const fs = require('fs');
+const fsSync = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const pjson = require('../package.json');
 const extract = require('extract-zip')
@@ -21,7 +22,7 @@ async function getDatasetSiteTemplate(singleFileMode) {
 
 function getDatasetSiteTemplateSync(singleFileMode) {
   // Get pre-rendered template from ./dist/
-  return fs.readFileSync(getDistFullPath(getDatasetSiteTemplateFilename(singleFileMode)), { encoding:'utf8' });
+  return fsSync.readFileSync(getDistFullPath(getDatasetSiteTemplateFilename(singleFileMode)), { encoding:'utf8' });
 }
 
 async function renderDatasetSite(jsonld, staticAssetsPathUrl) {
@@ -72,7 +73,7 @@ function renderDatasetSiteData(jsonld, staticAssetsPathUrl) {
 function copyFileFromDistToDirectorySync(destinationRelativeDirectoryPath, filename) {
   const sourcePath = getDistFullPath(filename);
   const destinationPath = path.join(process.cwd(), destinationRelativeDirectoryPath, filename);
-  fs.copyFileSync(sourcePath, destinationPath);
+  fsSync.copyFileSync(sourcePath, destinationPath);
 }
 
 async function unzipFileFromDistToDirectory(filename, destinationRelativeDirectoryPath) {
@@ -88,21 +89,21 @@ function copyTemplateSync(destinationRelativePath, singleFileMode) {
 
 function writeTemplatesToDirectorySync(destinationRelativeDirectoryPath) {
   // Create output directory if it does not already exist
-  fs.mkdirSync(path.join(process.cwd(), destinationRelativeDirectoryPath) , { recursive: true });
+  fsSync.mkdirSync(path.join(process.cwd(), destinationRelativeDirectoryPath) , { recursive: true });
   copyTemplateSync(destinationRelativeDirectoryPath, true);
   copyTemplateSync(destinationRelativeDirectoryPath, false);
 }
 
 function writeAssetsArchiveToDirectorySync(destinationRelativeDirectoryPath) {
   // Create output directory if it does not already exist
-  fs.mkdirSync(path.join(process.cwd(), destinationRelativeDirectoryPath) , { recursive: true });
+  fsSync.mkdirSync(path.join(process.cwd(), destinationRelativeDirectoryPath) , { recursive: true });
   
   copyFileFromDistToDirectorySync(destinationRelativeDirectoryPath, CSP_ASSET_ARCHIVE_FILENAME);
 }
 
 async function unzipAssetsArchiveToDirectory(destinationRelativeDirectoryPath) {
   // Create output directory if it does not already exist
-  fs.mkdirSync(path.join(process.cwd(), destinationRelativeDirectoryPath) , { recursive: true });
+  fsSync.mkdirSync(path.join(process.cwd(), destinationRelativeDirectoryPath) , { recursive: true });
   
   await unzipFileFromDistToDirectory(CSP_ASSET_ARCHIVE_FILENAME, destinationRelativeDirectoryPath);
 }


### PR DESCRIPTION
Fixes an issue with the `renderDatasetSite()` function.

Note that by default any PR on this repo may release a new version and cause a breaking change, so we need to work around this during release.