### PR TITLE
Conditional cicd npm version major

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,10 @@ jobs:
         id: filter
         with:
           filters: |
-            src:
+            src_templates:
               - 'src/templates/**'
       - name: Increment Version (for security - and CSP asset alignment - every change to the template files is a breaking change)
-        if: steps.filter.outputs.src == 'true'
+        if: steps.filter.outputs.src_templates == 'true'
         run: npm version major
       - name: Install and Build using incremented version
         run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,12 @@ jobs:
         id: filter
         with:
           filters: |
+            src_static:
+              - 'src/static/**'
             src_templates:
               - 'src/templates/**'
       - name: Increment Version (for security - and CSP asset alignment - every change to the template files is a breaking change)
-        if: steps.filter.outputs.src_templates == 'true'
+        if: steps.filter.outputs.src_static == 'true' || steps.filter.outputs.src_templates == 'true'
         run: npm version major
       - name: Install and Build using incremented version
         run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,14 @@ jobs:
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'src/templates/**'
       - name: Increment Version (for security - and CSP asset alignment - every change to the template files is a breaking change)
-        # TODO: Make this conditional on if template files have actually changed
+        if: steps.filter.outputs.src == 'true'
         run: npm version major
       - name: Install and Build using incremented version
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -215,4 +215,4 @@ All changes that impact the output dataset site templates or static assets MUST 
 
 Minor and patch version numbers may be used to update any functionality of the npm library that impacts direct users of that library, but does not impact the templates or static assets themselves.
 
-*NOTE*: All commits to master currently trigger a major version bump in CI by default.
+*NOTE*: Only commits to master src/static/ and src/templates/ currently trigger a major version bump in CI by default.


### PR DESCRIPTION
Allowing for NPM major version to only be incremented on changes to src/templates/, using the [paths-filter](https://github.com/dorny/paths-filter) custom action to act at the step-level rather than the full workflow-level. This will then allow for [PR 8](https://github.com/openactive/dataset-site-template/pull/8)(2023-03-15) to be finalised, as also seen in the issue board [here](https://github.com/orgs/openactive/projects/17/views/1?filterQuery=getDatasetSiteTemplate) and [here](https://github.com/orgs/openactive/projects/17/views/1?pane=issue&itemId=35347051&filterQuery=Fix+version+bumping).